### PR TITLE
add optional argument for specifying factorization strategy

### DIFF
--- a/src/cholesky_solver.cpp
+++ b/src/cholesky_solver.cpp
@@ -149,8 +149,7 @@ void csc_sum_duplicates(int n_rows, int &m_nnz, int **col_ptr, int **rows, doubl
 }
 
 template <typename Float>
-CholeskySolver<Float>::CholeskySolver(int n_rows, int nnz, int *ii, int *jj, double *x, MatrixType type, bool cpu) : m_n(n_rows), m_nnz(nnz), m_cpu(cpu) {
-
+CholeskySolver<Float>::CholeskySolver(int n_rows, int nnz, int *ii, int *jj, double *x, MatrixType type, bool cpu, int strategy) : m_n(n_rows), m_nnz(nnz), m_cpu(cpu) {
 
     // Placeholders for the CSC matrix data
     int *col_ptr, *rows;
@@ -188,7 +187,7 @@ CholeskySolver<Float>::CholeskySolver(int n_rows, int nnz, int *ii, int *jj, dou
     }
 
     // Run the Cholesky factorization through CHOLMOD and run the analysis
-    factorize(col_ptr, rows, data);
+    factorize(col_ptr, rows, data, strategy);
 
     if (type != MatrixType::CSC) {
         free(col_ptr);
@@ -198,12 +197,12 @@ CholeskySolver<Float>::CholeskySolver(int n_rows, int nnz, int *ii, int *jj, dou
 }
 
 template <typename Float>
-void CholeskySolver<Float>::factorize(int *col_ptr, int *rows, double *data) {
+void CholeskySolver<Float>::factorize(int *col_ptr, int *rows, double *data, int strategy) {
     cholmod_sparse *A;
 
     cholmod_start(&m_common);
 
-    m_common.supernodal = CHOLMOD_SIMPLICIAL;
+    m_common.supernodal = strategy;
     m_common.final_ll = 1; // compute LL' factorization instead of LDL´ (default for simplicial)
     m_common.nmethods = 1;
     m_common.method[0].ordering = CHOLMOD_NESDIS;

--- a/src/cholesky_solver.h
+++ b/src/cholesky_solver.h
@@ -32,8 +32,9 @@ public:
      * @param x Array of nonzero entries
      * @param type The type of the matrix representation. Can be COO, CSC or CSR
      * @param cpu Whether or not to run the CPU version of the solver.
+     * @param strategy 0: SIMPLICIAL, 1: AUTO, 2: SUPERNODAL
      */
-    CholeskySolver(int n_rows, int nnz, int *ii, int *jj, double *x, MatrixType type, bool cpu);
+    CholeskySolver(int n_rows, int nnz, int *ii, int *jj, double *x, MatrixType type, bool cpu, int strategy);
 
     ~CholeskySolver();
 
@@ -49,7 +50,7 @@ public:
 private:
 
     // Factorize the CSC matrix using CHOLMOD
-    void factorize(int *col_ptr, int *rows, double *data);
+    void factorize(int *col_ptr, int *rows, double *data, int strategy);
 
     // Run the analysis of a triangular matrix obtained through Cholesky
     void analyze_cuda(int n_rows, int n_entries, void *csr_rows, void *csr_cols, Float *csr_data, bool lower);

--- a/src/docstr.h
+++ b/src/docstr.h
@@ -16,6 +16,8 @@ Parameters
 - x - The array of nonzero entries.
 - type - The matrix representation type, of type MatrixType. Available types
          are MatrixType.COO, MatrixType.CSC and MatrixType.CSR.
+- strategy - the factorization strategy to be used by CHOLMOD. Available options are
+         0 (Simplicial), 1 (automatic selectiong, default), 2 (Supernodal).
 )";
 
 const char *doc_matrix_type =


### PR DESCRIPTION
Hi,

After reading about the significant performance difference between simplicial and supernodal factorization (https://github.com/rgl-epfl/cholespy/issues/25), I thought it would be beneficial to expose that as an option to the user. This PR adds a new argument to the CholeskySolver class to specify which option to use. CHOLMOD also apparently has an "AUTO" option which uses some heuristic to decide which strategy is appropriate for the provided matrix, so I use that as the default argument.

Since the new argument is defaulted, this change shouldn't break existing users' code, although it is potentially a change in the default behavior of CHOLMOD, which could change the runtime of existing code.

The performance of two test problems (as measured on a M2 macbook) are summarized below,

1. `get_icosphere(7)` (2D connectivity): supernodal was a 1.7x speedup over simplicial
2. a tetrahedron mesh of a sphere (3D connectivity): supernodal was a 4.1x speedup over simplicial

In both cases, the default "CHOLMOD_AUTO" option picked the faster (supernodal) approach.

The small performance test script (and relevant data for the tetrahedron mesh) is available [here](https://github.com/rgl-epfl/cholespy/files/13845973/perf_test.zip).